### PR TITLE
Automatically send message to existing session on page load if instructed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.4
+- When reconnecting to an existing chat session, the bot will send any message contained in the `?send=<message>` URL parameter once it has restored the socket.io connection
+
 ## 0.5.3
 - Added the parameter hideWhenNotConnected to not display the widget when the server is not connected (defaults to true)
 - Fixed issue where the 'connected' property was being loaded from previous session instead of being triggered on actual connection

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ emit('bot_uttered', message, room=socket_id)
 `storage: "local"` defines the state to be stored in the local stoage. The local storage persists after the the browser is closed, and is cleared when the cookies of the browser are cleared, or when `localStorage.clear()`is called.
 
 
+## Sending a message on page load
+
+When reconnecting to an existing chat session, the bot will send any message contained in the `?send=<message>` URL parameter once it has restored the socket.io connection. This is useful if you would like your bot to be able to offer your user to navigate around the site.
+
 
 ## API
 

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -71,6 +71,16 @@ class Widget extends Component {
         storeLocalSession(storage, SESSION_NAME, remote_id);
         this.props.dispatch(pullSession());
         this.trySendInitPayload()
+      } else {
+        // If this is an existing session, it's possible we changed pages and want to send a
+        // user message when we land.
+        const params = (new URL(document.location)).searchParams;
+        const send = params.get('send');
+
+        if (send) {
+          this.props.dispatch(addUserMessage(send));
+          this.props.dispatch(emitUserMessage(send));
+        }
       }
     });
 


### PR DESCRIPTION
**Proposed changes**:
When reconnecting to an existing chat session, the bot will send any message contained in the `?send=<message>` URL parameter once it has restored the socket.io connection.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
