### PR TITLE
Fix sender component overflow

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/styles.scss
@@ -12,7 +12,7 @@
 .widget-embedded {
   .messages-container {
     height: 100vh;
-    max-height: 100%;
+    max-height: calc(100vh - 90px); /* 90px: double the sender height */
   }
 }
 

--- a/src/components/Widget/components/Conversation/components/Messages/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/styles.scss
@@ -12,7 +12,7 @@
 .widget-embedded {
   .messages-container {
     height: 100vh;
-    max-height: calc(100vh - 90px); /* 90px: double the sender height */
+    max-height: calc(100vh - 100px); /* 100px: 2 * (sender height + padding) */
   }
 }
 

--- a/src/components/Widget/components/Conversation/components/Messages/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/styles.scss
@@ -11,8 +11,8 @@
 
 .widget-embedded {
   .messages-container {
-    height: 100vh;
-    max-height: calc(100vh - 100px); /* 100px: 2 * (sender height + padding) */
+    height: 100%;
+    max-height: 100%;
   }
 }
 


### PR DESCRIPTION
**Proposed changes**:
Could not see sender component when widget was embedded in Botfront under Firefox Quantum 60.7.0esr.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
