### PR TITLE
[Feature] Add option to use custom component on unknown incoming message data

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In your `<body/>`:
         }
       },
       storage: "local"
-    }
+    },
   })
 </script>
 ```
@@ -92,6 +92,7 @@ function CustomWidget = () => {
         },
         storage: "local"
       }}
+      customComponent: { (messageData) => (<div>Custom React component</div>) }
     />
   )
 }
@@ -196,6 +197,17 @@ message = {
 emit('bot_uttered', message, room=socket_id)
 ```
 
+###### sending a message with custom data
+
+```python
+message = {
+      "data":{
+        "customField1": 'anything you want',
+        "customField2": 'other custom data, 
+      }
+    }
+emit('bot_uttered', message, room=socket_id)
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ function CustomWidget = () => {
       initPayload={"/get_started"}
       socketUrl={"http://localhost:5500"}
       socketPath={"/socket.io/"}
-      customData: {{"userId": "123"}}, // arbitrary custom data. Stay minimal as this will be added to the socket
+      customData={{"userId": "123"}} // arbitrary custom data. Stay minimal as this will be added to the socket
       title={"Title"}
       inputTextFieldHint={"Type a message..."}
       connectingText={"Waiting for server..."}
@@ -92,7 +92,7 @@ function CustomWidget = () => {
         },
         storage: "local"
       }}
-      customComponent: { (messageData) => (<div>Custom React component</div>) }
+      customComponent={ (messageData) => (<div>Custom React component</div>) }
     />
   )
 }

--- a/src/components/Widget/components/Conversation/components/Messages/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/index.js
@@ -41,6 +41,8 @@ class Messages extends Component {
         case MESSAGES_TYPES.QUICK_REPLY: {
           return QuickReply
         }
+        case MESSAGES_TYPES.CUSTOM_COMPONENT:
+          return this.props.customComponent
       }
       return null
     })()
@@ -75,7 +77,8 @@ class Messages extends Component {
 
 Messages.propTypes = {
   messages: ImmutablePropTypes.listOf(ImmutablePropTypes.map),
-  profileAvatar: PropTypes.string
+  profileAvatar: PropTypes.string,
+  customComponent: PropTypes.func
 };
 
 export default connect(store => ({

--- a/src/components/Widget/components/Conversation/components/Messages/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/index.js
@@ -42,7 +42,10 @@ class Messages extends Component {
           return QuickReply
         }
         case MESSAGES_TYPES.CUSTOM_COMPONENT:
-          return this.props.customComponent
+          return connect(
+            store => ({ store }),
+            dispatch => ({ dispatch })
+          )(this.props.customComponent);
       }
       return null
     })()

--- a/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
@@ -26,6 +26,7 @@ describe('<Messages />', () => {
   const messagesComponent = shallow(
     <Messages.WrappedComponent
       messages={responseMessages}
+      customComponent={Dummy}
     />
   );
 
@@ -45,7 +46,7 @@ describe('<Messages />', () => {
     expect(messagesComponent.find(Image)).toHaveLength(1);
   });
 
-  it('should reder a custom component', () => {
+  it('should render a custom component', () => {
     expect(messagesComponent.find(Dummy)).toHaveLength(1);
   });
 });

--- a/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { List } from 'immutable';
 import { shallow } from 'enzyme';
 
-import { createNewMessage, createLinkSnippet, createVideoSnippet, createImageSnippet } from 'helper';
-import { createComponentMessage } from 'utils/messages';
+import { createNewMessage, createLinkSnippet, createVideoSnippet, createImageSnippet, createComponentMessage } from 'helper';
 
 import Messages from '../index';
 import Video from '../components/VidReply';
@@ -47,6 +46,6 @@ describe('<Messages />', () => {
   });
 
   it('should render a custom component', () => {
-    expect(messagesComponent.find(Dummy)).toHaveLength(1);
+    expect(messagesComponent.find('Connect(Dummy)')).toHaveLength(1);
   });
 });

--- a/src/components/Widget/components/Conversation/index.js
+++ b/src/components/Widget/components/Conversation/index.js
@@ -20,6 +20,7 @@ const Conversation = props =>
     <Messages
       profileAvatar={props.profileAvatar}
       params={props.params}
+      customComponent={props.customComponent}
     />
     <Sender
       sendMessage={props.sendMessage}
@@ -38,8 +39,8 @@ Conversation.propTypes = {
   params: PropTypes.object,
   connected: PropTypes.bool,
   connectingText: PropTypes.string,
-  closeImage: PropTypes.string
-
+  closeImage: PropTypes.string,
+  customComponent: PropTypes.func
 };
 
 export default Conversation;

--- a/src/components/Widget/components/Launcher/test/index.test.js
+++ b/src/components/Widget/components/Launcher/test/index.test.js
@@ -5,9 +5,9 @@ import Launcher from '../index';
 
 describe('<Launcher />', () => {
   const createMessageComponent = ({ toggle, chatOpened }) =>
-    shallow(<Launcher.WrappedComponent
+    shallow(<Launcher
       toggle={toggle}
-      chatOpened={chatOpened}
+      isChatOpen={chatOpened}
     />);
 
   it('should call toggle prop when clicked', () => {

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -13,6 +13,7 @@ import {
   addVideoSnippet,
   addImageSnippet,
   addQuickReply,
+  renderCustomComponent,
   initialize,
   connectServer,
   disconnectServer,
@@ -161,6 +162,7 @@ class Widget extends Component {
     if (Object.keys(message).length === 0) {
       return;
     }
+
     if (isText(message)) {
       this.props.dispatch(addResponseMessage(message.text));
     } else if (isQR(message)) {
@@ -185,6 +187,12 @@ class Widget extends Component {
         title: element.title,
         image: element.src
       }));
+    } else {
+      // some custom message
+      const props = message;
+      if (this.props.customComponent) {
+        this.props.dispatch(renderCustomComponent(this.props.customComponent, props, true));
+      }
     }
   }
 
@@ -217,6 +225,7 @@ class Widget extends Component {
         params={this.props.params}
         openLauncherImage={this.props.openLauncherImage}
         closeImage={this.props.closeImage}
+        customComponent={this.props.customComponent}
       />
     );
   }
@@ -248,7 +257,8 @@ Widget.propTypes = {
   connected: PropTypes.bool,
   initialized: PropTypes.bool,
   openLauncherImage: PropTypes.string,
-  closeImage: PropTypes.string
+  closeImage: PropTypes.string,
+  customComponent: PropTypes.func
 };
 
 Widget.defaultProps = {

--- a/src/components/Widget/layout.js
+++ b/src/components/Widget/layout.js
@@ -37,6 +37,7 @@ const WidgetLayout = (props) => {
           connected={props.connected}
           connectingText={props.connectingText}
           closeImage={props.closeImage}
+          customComponent={props.customComponent}
         />
       }
       {
@@ -81,7 +82,8 @@ WidgetLayout.propTypes = {
   connected: PropTypes.bool,
   connectingText: PropTypes.string,
   openLauncherImage: PropTypes.string,
-  closeImage: PropTypes.string
+  closeImage: PropTypes.string,
+  customComponent: PropTypes.func
 };
 
 export default connect(mapStateToProps)(WidgetLayout);

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ const ConnectedWidget = (props) => {
       storage={storage}
       openLauncherImage={props.openLauncherImage}
       closeImage={props.closeImage}
+      customComponent={props.customComponent}
     />
   </Provider>);
 };
@@ -59,7 +60,8 @@ ConnectedWidget.propTypes = {
   params: PropTypes.object,
   openLauncherImage: PropTypes.string,
   closeImage: PropTypes.string,
-  docViewer: PropTypes.bool
+  docViewer: PropTypes.bool,
+  customComponent: PropTypes.func
 };
 
 ConnectedWidget.defaultProps = {


### PR DESCRIPTION
**Proposed changes**:
Rasa lets you send custom data to clients. This change lets you specify a custom component to handle the custom data.
[This rasa community thread](https://forum.rasa.com/t/sending-custom-json-payload-from-actions-workaround-for-utter-custom-message/9139) demonstrates the want for this feature and mentions that rasa-webchat did not support this.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
