### PR TITLE
Fix/redux clear

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -125,10 +125,6 @@ class Widget extends Component {
     return local_id;
   }
 
-  // TODO: Need to erase redux store on load if localStorage
-  // is erased. Then behavior on reload can be consistent with
-  // behavior on first load
-
   trySendInitPayload = () => {
     const {
       initPayload,

--- a/src/store/reducers/behaviorReducer.js
+++ b/src/store/reducers/behaviorReducer.js
@@ -17,6 +17,10 @@ export default function (inputFieldTextHint, connectingText, storage, docViewer 
 
   return function reducer(state = initialState, action) {
     const storeParams = storeParamsTo(storage);
+
+    const localSession = getLocalSession(storage, SESSION_NAME);
+    if (!localSession) state = initialState;
+
     switch (action.type) {
       // Each change to the redux store's behavior Map gets recorded to storage
       case actionTypes.SHOW_CHAT: {
@@ -54,8 +58,6 @@ export default function (inputFieldTextHint, connectingText, storage, docViewer 
       }
       // Pull params from storage to redux store
       case actionTypes.PULL_SESSION: {
-        const localSession = getLocalSession(storage, SESSION_NAME);
-
         // Do not persist connected state
         const connected = state.get('connected');
 


### PR DESCRIPTION
**Proposed changes**:
This clears the redux state if storage is empty. This allows the app to behave the same when storage is cleared as when the app first starts up.

In the removed comment it implies that the check was intended to only be when initializing. However, if you clear the storage and reload the page the `disconnect` action happens and so the state and storage don't stay cleared after reload.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
