### PR TITLE
feat: support web url in quick replies

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,40 @@
 steps:
 - name: 'gcr.io/cloud-builders/npm'
   args: ['install']
+
 - name: 'gcr.io/cloud-builders/npm'
   args: ['run','build']
+
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp', 'lib/index.js', 'gs://mrbot-cdn/webchat-$TAG_NAME.js']
+
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp', 'lib/index.js', 'gs://mrbot-cdn/webchat-latest.js']
+
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['acl', 'ch', '-u', 'AllUsers:R', 'gs://mrbot-cdn/webchat-$TAG_NAME.js']
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['acl', 'ch', '-u', 'AllUsers:R', 'gs://mrbot-cdn/webchat-latest.js']
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  args:
+  - kms
+  - decrypt
+  - --ciphertext-file=npmrc.enc
+  - --plaintext-file=/root/.npmrc
+  - --location=global
+  - --keyring=my-keyring
+  - --key=npm-key
+  volumes:
+  - name: 'home'
+    path: /root/
+
+- name: 'gcr.io/cloud-builders/npm'
+  args:
+    - publish
+  dir: cli
+  env:
+  - HOME=/root/
+  volumes:
+  - name: 'home'
+    path: /root/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9877,6 +9877,12 @@
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -12531,6 +12537,15 @@
         "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
         "symbol-observable": "^1.0.3"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.3.tgz",
+      "integrity": "sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "prettier-eslint": "^5.1.0",
     "react": "^15.6.2",
     "react-test-renderer": "^15.6.2",
+    "redux-mock-store": "^1.5.3",
     "sass-loader": "^6.0.7",
     "socket.io-client": "^2.1.1",
     "standard-version": "^7.0.0",

--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
@@ -30,20 +30,41 @@ class QuickReply extends PureComponent {
   render() {
     const chosenReply = this.props.getChosenReply(this.props.id);
     if (chosenReply) {
-      return <Message message={this.props.message} />
+      return <Message message={this.props.message} />;
     }
     return (
       <div>
         <Message message={this.props.message} />
-        {this.props.isLast &&
+        {this.props.isLast && (
         <div className="replies">
-          {this.props.message.get('quick_replies').map((reply, index) => <div
-            key={index} className={'reply'}
+            {this.props.message.get("quick_replies").map((reply, index) => {
+              if(reply.type === 'web_url') {
+                return (
+                  <a
+                    key={index}
+                    href={reply.payload}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={'reply'}
+                  >
+                    {reply.title}
+                  </a>
+                );
+              }
+              return (
+                <div
+                  key={index}
+                  className={"reply"}
             onClick={this.handleClick.bind(this, reply)}
-          >{reply.title}</div>)}
+                >
+                  {reply.title}
+                </div>
+              );
+            })}
+          </div>
+        )}
         </div>
-        }
-      </div>);
+    );
   }
 }
 

--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/index.js
@@ -54,8 +54,8 @@ class QuickReply extends PureComponent {
               return (
                 <div
                   key={index}
-                  className={"reply"}
-            onClick={this.handleClick.bind(this, reply)}
+                  className={'reply'}
+                  onClick={this.handleClick.bind(this, reply)}
                 >
                   {reply.title}
                 </div>

--- a/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/QuickReply/test/index.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { render } from 'enzyme';
+
+import { createQuickReply } from 'helper';
+import QuickReply from '../index';
+
+
+describe('<QuickReply />', () => {
+  const quickReply = createQuickReply({
+    text: 'test',
+    quick_replies: [
+      {
+        type: 'postback',
+        content_type: 'text',
+        title: 'Button title 1',
+        payload: '/payload1'
+      },
+      {
+        type: 'web_url',
+        content_type: 'text',
+        title: 'google',
+        payload: 'http://www.google.ca'
+      }
+    ]
+  });
+
+  quickReply.set('docViewer', false);
+  const mockStore = configureMockStore();
+  const store = mockStore({ getChosenReply: () => undefined, inputState: false, messages: new Map([[1, new Map([['chosenReply', undefined]])]]), behavior: new Map([['disabledInput', false]]) });
+
+  const quickReplyComponent = render(
+    <Provider store={store}>
+      <QuickReply
+        params={null}
+        id={1}
+        message={quickReply}
+        isLast
+      />
+    </Provider>
+  );
+
+  it('should render a quick reply with a link to google', () => {
+    expect(quickReplyComponent.find('a.reply')).toHaveLength(1);
+    expect(quickReplyComponent.find('a.reply').html()).toEqual('google');
+    expect(quickReplyComponent.find('a.reply').prop('href')).toEqual('http://www.google.ca');
+  });
+});

--- a/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
+++ b/src/components/Widget/components/Conversation/components/Messages/test/index.test.js
@@ -2,25 +2,64 @@ import React from 'react';
 import { List } from 'immutable';
 import { shallow } from 'enzyme';
 
-import { createNewMessage, createLinkSnippet, createVideoSnippet, createImageSnippet, createComponentMessage } from 'helper';
+import {
+  createNewMessage,
+  createLinkSnippet,
+  createVideoSnippet,
+  createImageSnippet,
+  createComponentMessage,
+  createQuickReply
+} from 'helper';
 
 import Messages from '../index';
 import Video from '../components/VidReply';
 import Image from '../components/ImgReply';
 import Message from '../components/Message';
+import QuickReply from '../components/QuickReply';
+
 import Snippet from '../components/Snippet';
 
 describe('<Messages />', () => {
   const message = createNewMessage('Response message 1');
   const linkSnippet = createLinkSnippet({ title: 'link', link: 'link' });
   const srcVideo = createVideoSnippet({ title: 'video', video: 'video' });
-  const srcImage = createImageSnippet({ title: 'image', image: 'image', dims: { 'width': 100, 'height': 100 } });
+  const srcImage = createImageSnippet({
+    title: 'image',
+    image: 'image',
+    dims: { width: 100, height: 100 }
+  });
   /* eslint-disable react/prop-types */
   const Dummy = ({ text }) => <div>{text}</div>;
   /* eslint-enable */
-  const customComp = createComponentMessage(Dummy, { text: 'This is a Dummy Component!' });
+  const customComp = createComponentMessage(Dummy, {
+    text: 'This is a Dummy Component!'
+  });
+  const quickReply = createQuickReply({
+    text: 'test',
+    quick_replies: [
+      {
+        type: 'postback',
+        content_type: 'text',
+        title: 'Button title 1',
+        payload: '/payload1'
+      },
+      {
+        type: 'web_url',
+        content_type: 'text',
+        title: 'google',
+        payload: 'http://www.google.ca'
+      }
+    ]
+  });
 
-  const responseMessages = List([message, linkSnippet, srcVideo, srcImage, customComp]);
+  const responseMessages = List([
+    message,
+    linkSnippet,
+    srcVideo,
+    srcImage,
+    customComp,
+    quickReply
+  ]);
 
   const messagesComponent = shallow(
     <Messages.WrappedComponent
@@ -47,5 +86,9 @@ describe('<Messages />', () => {
 
   it('should render a custom component', () => {
     expect(messagesComponent.find('Connect(Dummy)')).toHaveLength(1);
+  });
+
+  it('should render a QuickReply component', () => {
+    expect(messagesComponent.find(QuickReply)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
**Proposed changes**:
- add support of web_url types in quick replies
rely on this PR :  https://github.com/botfront/rasa-addons/pull/48

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
        test: should render a quick reply with a link to google
- [ ] updated the documentation
- [ ] updated the changelog
