### PR TITLE
fix: cast messages text into string to prevent crashes

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -42,7 +42,8 @@ class Widget extends Component {
     const { socket, storage } = this.props;
 
     socket.on('bot_uttered', (botUttered) => {
-      this.messages.push(botUttered);
+      const newMessage = { ...botUttered, text: String(botUttered.text) };
+      this.messages.push(newMessage);
     });
 
     this.props.dispatch(pullSession());


### PR DESCRIPTION
realate to  issue #126

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
