### PR TITLE
feat: add margin to <p> to display newline

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
@@ -35,6 +35,14 @@
   /* For markdown elements created with default styles */
   .message-text {
     margin: 0;
+    .markdown{
+      p{
+        margin-bottom: 1em;
+      }
+      :last-child{
+        margin-bottom: 0px;
+      }
+    }
   }
   
   .avatar {

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
@@ -39,7 +39,7 @@
       p{
         margin-bottom: 1em;
         &:last-child{
-          margin-bottom: 0px;
+          margin-bottom: 0;
         }
       }
     }

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
@@ -38,9 +38,9 @@
     .markdown{
       p{
         margin-bottom: 1em;
-      }
-      :last-child{
-        margin-bottom: 0px;
+        &:last-child{
+          margin-bottom: 0px;
+        }
       }
     }
   }


### PR DESCRIPTION
**Proposed changes**:
- Add a margin to the bottom of <p> tags that are not the last element of their parent. this better shows new lines that use the markdown format "{2 spaces}\n"

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality (this is exclusively a css change)
- [ ] updated the documentation
- [ ] updated the changelog
